### PR TITLE
feat: add SanitizeTextPipe for sanitizing text input

### DIFF
--- a/src/common/pipes/sanitize-text.pipe.ts
+++ b/src/common/pipes/sanitize-text.pipe.ts
@@ -1,0 +1,21 @@
+import { PipeTransform, Injectable, ArgumentMetadata, BadRequestException } from '@nestjs/common';
+import { stripHtml } from 'string-strip-html';
+
+@Injectable()
+export class SanitizeTextPipe implements PipeTransform {
+    transform(value: any, metadata: ArgumentMetadata) {
+        if (!value || typeof value !== 'object') return value;
+
+        if ('text' in value) {
+            const result = stripHtml(value.text).result.trim();
+
+            if (!result) {
+                throw new BadRequestException('Comment text must not be empty after sanitization');
+            }
+
+            value.text = result;
+        }
+
+        return value;
+    }
+}


### PR DESCRIPTION
Overview

This PR introduces a new custom NestJS pipe named SanitizeTextPipe. The pipe is responsible for sanitizing text input by stripping any HTML content and trimming whitespace. It ensures that input such as user comments or messages do not contain empty or potentially unsafe HTML after sanitization.

Changes

Created SanitizeTextPipe implementing PipeTransform.
Utilized stripHtml to sanitize the text field in incoming requests.
Throws BadRequestException if sanitized content is empty.
Decorated the class with @Injectable() for dependency injection compatibility.
Motivation

The sanitization layer helps prevent XSS attacks and ensures content quality in user-generated text fields (e.g., comments, posts). This is a foundational step toward robust and secure input handling.

Impact

No breaking changes.
Pipe is self-contained and reusable across controllers.
Requires registration in relevant modules or controller-level usage to take effect.
Next Steps

Integrate SanitizeTextPipe into controller endpoints accepting text input.
Write unit tests for edge cases and validation coverage (optional follow-up).
